### PR TITLE
Fix typo 'briliant'

### DIFF
--- a/index_old.html
+++ b/index_old.html
@@ -94,7 +94,7 @@
                         <a href="http://www.hetpaleisgroningen.nl/">Het Paleis</a>, Boterdiep 111 in Groningen (<a href="https://www.google.com/maps/place/Het+Paleis/@53.2258138,6.5627365,18.38z/data=!4m2!3m1!1s0x0:0x4584851851b7c5c7">map</a>)</p>
                         <img src="http://www.hetpaleisgroningen.nl/data/imagecache/DSC05072_3_1.jpg" width="200" alt="Missing picture of Het Paleis" />
                         <h1>Tickets</h1>
-                        <p>Web11 is a non-profit conference foccused on open-source technologies. The ticketprice includes a day filled with briliant talks, drinks and lunch! There will only be 100 tickets so be quick to get yours ticket to Web11!</p>
+                        <p>Web11 is a non-profit conference foccused on open-source technologies. The ticketprice includes a day filled with brilliant talks, drinks and lunch! There will only be 100 tickets so be quick to get yours ticket to Web11!</p>
                         <p align="center">
                             <iframe src="https://frontoffice.paylogic.nl/?event_id=106009&point_of_sale_id=12818" width="650" height="750" frameborder="0" marginwidth="0" marginheight="0" scrolling="auto"></iframe>
                         </p>


### PR DESCRIPTION
```
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'brilliant', you typed 'briliant'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
```
